### PR TITLE
fix: render confetti when lesson is solved

### DIFF
--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+
+export function useRequestAnimationFrame(callback: () => void) {
+    const ref = useRef<number>(0);
+
+    useEffect(() => {
+        function onFrame() {
+            callback();
+            ref.current = requestAnimationFrame(onFrame);
+        }
+
+        ref.current = requestAnimationFrame(onFrame);
+
+        return () => cancelAnimationFrame(ref.current!);
+    }, [callback]);
+
+    return ref.current;
+}

--- a/src/components/lessons/04/lesson-04.tsx
+++ b/src/components/lessons/04/lesson-04.tsx
@@ -7,9 +7,9 @@ import img5 from '../../../assets/phto-5.png';
 import img6 from '../../../assets/phto-6.png';
 import { Image } from '../../common/image/image';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
+import { useRequestAnimationFrame } from '../../hooks';
 import { Task04 as Task } from '../../tasks/04/task-04';
 import styles from './lesson-04.module.scss';
-import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson04 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);

--- a/src/components/lessons/04/lesson-04.tsx
+++ b/src/components/lessons/04/lesson-04.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import img1 from '../../../assets/phto-1.png';
 import img2 from '../../../assets/phto-2.png';
 import img3 from '../../../assets/phto-3.png';
@@ -9,13 +9,16 @@ import { Image } from '../../common/image/image';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
 import { Task04 as Task } from '../../tasks/04/task-04';
 import styles from './lesson-04.module.scss';
+import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson04 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);
 
-    useEffect(() => {
+    const checkSolution = useCallback(() => {
         setLessonSolved(isSolved());
     }, []);
+
+    useRequestAnimationFrame(checkSolution);
 
     return (
         <div className={styles.root}>

--- a/src/components/lessons/05/lesson-05.tsx
+++ b/src/components/lessons/05/lesson-05.tsx
@@ -1,19 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import styles from './lesson-05.module.scss';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
 import { Task05 as Task } from '../../tasks/05/task-05';
+import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson05 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);
 
-    useEffect(() => {
-        const timeoutId = setTimeout(() => {
-            setLessonSolved(isSolved());
-        }, 750);
-
-        return () => clearTimeout(timeoutId);
+    const checkSolution = useCallback(() => {
+        setLessonSolved(isSolved());
     }, []);
+
+    useRequestAnimationFrame(checkSolution);
 
     return (
         <div className={styles.root}>

--- a/src/components/lessons/05/lesson-05.tsx
+++ b/src/components/lessons/05/lesson-05.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
-import styles from './lesson-05.module.scss';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
-import { Task05 as Task } from '../../tasks/05/task-05';
 import { useRequestAnimationFrame } from '../../hooks';
+import { Task05 as Task } from '../../tasks/05/task-05';
+import styles from './lesson-05.module.scss';
 
 export const Lesson05 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);

--- a/src/components/lessons/06/lesson-06.tsx
+++ b/src/components/lessons/06/lesson-06.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
 import vars from '../../../globals/variables.module.scss';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
+import { useRequestAnimationFrame } from '../../hooks';
 import { Task06 as Task } from '../../tasks/06/task-06';
 import styles from './lesson-06.module.scss';
-import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson06 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);

--- a/src/components/lessons/06/lesson-06.tsx
+++ b/src/components/lessons/06/lesson-06.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import vars from '../../../globals/variables.module.scss';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
 import { Task06 as Task } from '../../tasks/06/task-06';
 import styles from './lesson-06.module.scss';
+import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson06 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);
 
-    useEffect(() => {
+    const checkSolution = useCallback(() => {
         setLessonSolved(isSolved());
     }, []);
+
+    useRequestAnimationFrame(checkSolution);
 
     return (
         <div className={styles.root}>

--- a/src/components/lessons/08/lesson-08.tsx
+++ b/src/components/lessons/08/lesson-08.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
+import { useRequestAnimationFrame } from '../../hooks';
 import { Task08 as Task } from '../../tasks/08/task-08';
 import styles from './lesson-08.module.scss';
-import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson08 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);

--- a/src/components/lessons/08/lesson-08.tsx
+++ b/src/components/lessons/08/lesson-08.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
 import { Task08 as Task } from '../../tasks/08/task-08';
 import styles from './lesson-08.module.scss';
+import { useRequestAnimationFrame } from '../../hooks';
 
 export const Lesson08 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);
 
-    useEffect(() => {
+    const checkSolution = useCallback(() => {
         setLessonSolved(isSolved());
     }, []);
+
+    useRequestAnimationFrame(checkSolution);
 
     return (
         <div className={styles.root}>

--- a/src/components/lessons/09/lesson-09.tsx
+++ b/src/components/lessons/09/lesson-09.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { ColorName } from '../../../globals/colors';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
 import { Task09 as Task } from '../../tasks/09/task-09';
 import styles from './lesson-09.module.scss';
+import { useRequestAnimationFrame } from '../../hooks';
 
 const boxes: ColorName[] = [
     'turquoiseGreen',
@@ -121,9 +122,11 @@ const boxes: ColorName[] = [
 export const Lesson09 = () => {
     const [lessonSolved, setLessonSolved] = useState(false);
 
-    useEffect(() => {
+    const checkSolution = useCallback(() => {
         setLessonSolved(isSolved());
     }, []);
+
+    useRequestAnimationFrame(checkSolution);
 
     return (
         <div className={styles.root}>

--- a/src/components/lessons/09/lesson-09.tsx
+++ b/src/components/lessons/09/lesson-09.tsx
@@ -2,9 +2,9 @@ import { useCallback, useState } from 'react';
 import type { ColorName } from '../../../globals/colors';
 import { Box } from '../../common/box/box';
 import { ConfettiFx } from '../../fx/confetti-fx/confetti-fx';
+import { useRequestAnimationFrame } from '../../hooks';
 import { Task09 as Task } from '../../tasks/09/task-09';
 import styles from './lesson-09.module.scss';
-import { useRequestAnimationFrame } from '../../hooks';
 
 const boxes: ColorName[] = [
     'turquoiseGreen',


### PR DESCRIPTION
Solves this issue: https://github.com/wixplosives/codux/issues/17701
Together with this PR for online: https://github.com/codux-demos/intro-tutorial/pull/107
Completed lessons doesn't need any change (do not use confetti at all).