### PR TITLE
feat: add new UI Kit lesson in standalone board

### DIFF
--- a/_codux/boards/ui-k.board.module.scss
+++ b/_codux/boards/ui-k.board.module.scss
@@ -1,0 +1,103 @@
+@import '../../src/globals/variables.module.scss';
+.root {
+  display: flex;
+  height: 100vh;
+}
+
+.task {
+  width: 250px;
+  margin-right: 58px;
+  margin-left: 45px;
+  font: 15px/26px $font-family-text;
+}
+
+.uiKitContent {
+  width: 810px;
+  margin-top: 53px;
+  margin-right: 60px;
+  display: flex;
+}
+
+.boardTitle {
+  font: $task-font-title;
+  margin-bottom: 36px;
+  margin-top: 63px;
+}
+
+.dropArea {
+  width: 174px;
+  min-height: 49px;
+  border: 1px dashed black;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.dropArea:empty::before {
+  content: 'Drop variant here';
+  position: absolute;
+  color: #a7a7a7;
+  margin: 11px 25px;
+}
+
+.sectionTitle {
+  font-size: 11px;
+  line-height: 14px;
+  height: 34px;
+  align-content: center;
+  margin-bottom: 7px;
+}
+
+.uiKitSection {
+  background-color: #f5f5f5;
+  height: 450px;
+  padding-left: 30px;
+  padding-top: 30px;
+}
+
+.navSection {
+  width: 226px;
+}
+
+.typographySection {
+  width: 335px;
+}
+
+.graphicsSection {
+  width: 240px;
+}
+
+.uiTitle {
+  font-size: 20px;
+  line-height: 30px;
+  font-weight: 600;
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
+.sectionItem {
+  margin-bottom: 30px;
+}
+
+.icon {
+  width: 60px;
+  border-radius: $box-border-radius-circle;
+  background-color: #0f0f0f;
+}
+
+.iconContainer {
+  display: flex;
+  column-gap: 4px;
+}
+
+.socialContainer {
+  height: 30px;
+  display: flex;
+  column-gap: 15px;
+}
+
+.paragraphBox {
+  width: 250px;
+}

--- a/_codux/boards/ui-k.board.tsx
+++ b/_codux/boards/ui-k.board.tsx
@@ -1,0 +1,168 @@
+import { createBoard, Variant } from '@wixc3/react-board';
+import { TaskTag } from '~/components/common/task-tag/task-tag';
+import { Box } from '~/components/common/box/box';
+import styles from './ui-k.board.module.scss';
+import taskStyles from '../../src/components/tasks/task.module.scss';
+import { Pupil } from '../../src/components/pupil/pupil';
+import { ConfettiFx } from '~/components/fx/confetti-fx/confetti-fx';
+import { useEffect, useState } from 'react';
+import { SocialIcon } from '~/components/social-icon/social-icon';
+import { TaskSymbol } from '~/components/common/task-symbol/task-symbol';
+
+export default createBoard({
+    name: 'UI Kit',
+    Board: () => {
+        const [lessonSolved, setLessonSolved] = useState(false);
+        useEffect(() => {
+            setLessonSolved(isSolved());
+        }, []);
+
+        return (
+            <div className={styles.root}>
+                <div className={styles.task}>
+                    <h1 className={styles.boardTitle}>UI Kit</h1>
+                    <p>
+                        <b>UI Kit Variants</b> help you keep design consistent. They can be re-used
+                        across your project through the Add Elements panel, under the{' '}
+                        <b>UI Kit section</b>.{' '}
+                    </p>
+                    <ol>
+                        <li>
+                            <br />
+                            1. Make <TaskTag type="tree" children="div.menuIcon" /> a part of the UI
+                            Kit: Right click on it, select <b>‘Create Variant’</b> and give it a
+                            name.
+                        </li>
+                        <li>
+                            <br />
+                            2. Open the <TaskSymbol name="add" />
+                            Add Elements Panel and add the variant from the <b>UI Kit.</b>
+                        </li>
+                        <br />
+                    </ol>
+                    <div id="drop-area" className={styles.dropArea}></div>
+                </div>
+                <div className={styles.uiKitContent}>
+                    <div className={styles.navSection}>
+                        <h2 className={styles.sectionTitle}>NAVIGATION</h2>
+                        <div className={styles.uiKitSection}>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Menu</h3>
+                                <div data-menu className={taskStyles.menuIcon}>
+                                    <div className={taskStyles.upperMenuIcon} />
+                                    <div className={taskStyles.lowerMenuIcon} />
+                                </div>
+                            </div>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Steps</h3>
+                                <Variant name="Steps">
+                                    <div className={taskStyles.progress}>
+                                        <b>07</b> / 10
+                                    </div>
+                                </Variant>
+                            </div>
+                        </div>
+                    </div>
+                    <div className={styles.typographySection}>
+                        <h2 className={styles.sectionTitle}>TYPOGRAPHY</h2>
+                        <div className={styles.uiKitSection}>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Title</h3>
+                                <Variant name="Title">
+                                    <h1 className={taskStyles.title}>Lesson Title</h1>
+                                </Variant>
+                            </div>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Paragraph</h3>
+                                <div className={styles.paragraphBox}>
+                                    <Variant name="Paragraph">
+                                        <p>
+                                            This is an introductory text that explains the{' '}
+                                            <b>purpose of each lesson</b>, and provides key steps on
+                                            how to <b>solve it</b>.
+                                        </p>
+                                    </Variant>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div className={styles.graphicsSection}>
+                        <h2 className={styles.sectionTitle}>GRAPHICS</h2>
+                        <div className={styles.uiKitSection}>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Elements</h3>
+                                <Pupil />
+                            </div>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Icons</h3>
+                                <div className={styles.iconContainer}>
+                                    <Variant name="Heart Outline Icon">
+                                        <Box
+                                            outlined={false}
+                                            color="charcoalBlack"
+                                            icon="heartOutline"
+                                            iconColor="pastelPink"
+                                            className={taskStyles.roundIcon}
+                                        />
+                                    </Variant>
+                                    <Variant name="Heart Outline Icon">
+                                        <Box
+                                            outlined={false}
+                                            color="charcoalBlack"
+                                            icon="arrow"
+                                            iconDirection="right"
+                                            iconColor="white"
+                                            className={taskStyles.roundIcon}
+                                        />
+                                    </Variant>
+                                    <Variant name="Heart Outline Icon">
+                                        <Box
+                                            color="charcoalBlack"
+                                            icon="heart"
+                                            className={taskStyles.roundIcon}
+                                            iconColor="pastelPink"
+                                        />
+                                    </Variant>
+                                </div>
+                            </div>
+                            <div className={styles.sectionItem}>
+                                <h3 className={styles.uiTitle}>Social</h3>
+                                <div className={styles.socialContainer}>
+                                    <Variant name="X Icon">
+                                        <SocialIcon name="x" />
+                                    </Variant>
+                                    <Variant name="Discord Icon">
+                                        <SocialIcon name="discord" />
+                                    </Variant>
+
+                                    <Variant name="YouTube Icon">
+                                        <SocialIcon name="youtube" />
+                                    </Variant>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <ConfettiFx
+                    maxParticles={200}
+                    show={lessonSolved}
+                    style={{
+                        display: lessonSolved ? 'block' : 'none',
+                    }}
+                />
+            </div>
+        );
+    },
+    environmentProps: {
+        windowHeight: 596,
+        windowWidth: 1211,
+    },
+    isSnippet: true,
+});
+
+function isSolved(): boolean {
+    const elem = document.getElementById('drop-area');
+    console.log(elem?.firstElementChild?.getAttribute('data-menu'));
+
+    return !!elem?.firstElementChild?.getAttribute('data-menu');
+}

--- a/src/components/common/task-tag/task-tag.tsx
+++ b/src/components/common/task-tag/task-tag.tsx
@@ -1,12 +1,13 @@
 import styles from './task-tag.module.scss';
 import { TaskSymbol } from '../task-symbol/task-symbol';
+import { ReactNode } from 'react';
 
 type TypeName = 'stage' | 'stage-comp' | 'tree' | 'selector';
 
 export interface TaskTagProps {
     type: TypeName;
     chevron?: boolean;
-    children: string;
+    children: ReactNode;
 }
 
 export const TaskTag = ({ chevron = false, type, children }: TaskTagProps) => {

--- a/src/components/social-icon/social-icon.tsx
+++ b/src/components/social-icon/social-icon.tsx
@@ -1,0 +1,30 @@
+import XLogo from '../../assets/x.svg?react';
+import DiscordLogo from '../../assets/discord.svg?react';
+import YoutubeLogo from '../../assets/youtube.svg?react';
+import taskStyles from '../tasks/task.module.scss';
+
+export interface SocialIconProps {
+    name: 'x' | 'discord' | 'youtube';
+}
+
+export const SocialIcon = ({ name = 'youtube' }: SocialIconProps) => {
+    return (
+        <>
+            {name === 'x' && (
+                <a href="https://discord.com/channels/1047628695675863150" target="_blank">
+                    <XLogo className={taskStyles.socialIcon} />
+                </a>
+            )}
+            {name === 'discord' && (
+                <a href="https://discord.com/channels/1047628695675863150" target="_blank">
+                    <DiscordLogo className={taskStyles.socialIcon} />
+                </a>
+            )}
+            {name === 'youtube' && (
+                <a href="https://www.youtube.com/@CoduxIDE" target="_blank">
+                    <YoutubeLogo className={taskStyles.socialIcon} />
+                </a>
+            )}
+        </>
+    );
+};

--- a/src/components/tasks/task.module.scss
+++ b/src/components/tasks/task.module.scss
@@ -8,33 +8,79 @@
   box-sizing: border-box;
   overflow: hidden;
   width: $task-width;
+}
 
-  .progress {
-    font: $task-font-progress;
-    letter-spacing: 0.2em;
+.progress {
+  font: $task-font-progress;
+  letter-spacing: 0.2em;
+}
+
+.title {
+  font: $task-font-title;
+  padding-top: 1.5rem;
+  padding-bottom: 1.3rem;
+}
+
+.desc {
+  font: $task-font-description;
+  text-align: $task-text-align;
+  list-style-type: decimal;
+  list-style-position: outside;
+  padding-left: 1rem;
+  margin-top: 0;
+
+  li:not(:last-of-type) {
+    margin-bottom: 1rem;
   }
 
-  .title {
-    font: $task-font-title;
-    padding-top: 1.5rem;
-    padding-bottom: 1.3rem;
+  li:first-of-type {
+    list-style-type: none;
+    margin-left: -1rem;
   }
+}
 
-  .desc {
-    font: $task-font-description;
-    text-align: $task-text-align;
-    list-style-type: decimal;
-    list-style-position: outside;
-    padding-left: 1rem;
-    margin-top: 0;
+.roundIcon {
+  width: 60px;
+  border-radius: $box-border-radius-circle;
+  padding: 14px;
+}
 
-    li:not(:last-of-type) {
-      margin-bottom: 1rem;
-    }
+.socialIcon {
+  height: 30px;
+  width: 30px;
+}
 
-    li:first-of-type {
-      list-style-type: none;
-      margin-left: -1rem;
-    }
-  }
+.menuIcon {
+  width: 60px;
+  height: 60px;
+  position: relative;
+  cursor: pointer;
+  background-color: #000000;
+}
+
+.upperMenuIcon {
+  width: 16px;
+  height: 4px;
+  background-color: #ffffff;
+  position: absolute;
+  top: 24px;
+  left: 25px;
+}
+
+.lowerMenuIcon {
+  width: 16px;
+  height: 4px;
+  background-color: #ffffff;
+  position: absolute;
+  top: 32px;
+  left: 16px;
+}
+
+.boldText {
+  font-weight: 800;
+}
+
+.navButtons {
+  display: flex;
+  gap: 8px;
 }


### PR DESCRIPTION
Figma: https://www.figma.com/design/hGXNAqe3V5y4g2GP8EJ68f/Define-App---Tutorial-HP?node-id=237-736&t=Hsnx40Y9sacRR90R-1

Notes:
1. Removed Navbar from lesson after building it after seeing that it involves Remix Links with a `MemoryRouter` and it doesn't work right now.
2. Original design didn't take into account the existing styles of the Title & Paragraph, this means there's a lot more padding in the board, compared to the design (can create a design just for here that is different to the rest of tutorial, change all other places, or rework the board somehow).
3. Needed to create a `SocialIcon` component so that would take care of SVG imports for me. I did not replace all other place in the tutorial to use it.
4. Flattened the top level of `task.module.scss` (so I could include its Title and Paragraph styling), this could have unexpected consequences and should be properly validated.
5. I added any classes I needed for Variants to the same `task.module.scss` file.
6. I know a CSS reset is coming to the tutorial, I did not validate against it.
7. Fixed `children` type on `task-tag` component
7. Someone please delete the Pupil board.