### PR TITLE
fix(package.json): add version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "codux-intro-tutorial",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codux-intro-tutorial",
+      "version": "1.0.0",
       "dependencies": {
         "@remix-run/node": "^2.14.0",
         "@remix-run/react": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "codux-intro-tutorial",
+  "version": "1.0.0",
   "private": true,
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
There was an issue with the online version of codux that was originated from the missing `version` field in the package.json.